### PR TITLE
cm: Fix Trusted Face

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -146,8 +146,9 @@ PRODUCT_PACKAGES += \
     PhotoTable \
     Terminal
 
-# Include librsjni explicitly to workaround GMS issue
+# Include explicitly to work around GMS issues
 PRODUCT_PACKAGES += \
+    libprotobuf-cpp-full \
     librsjni
 
 # Custom CM packages


### PR DESCRIPTION
Trusted Face depends on libprotobuf-cpp-full.
Some devices already ship it (eg RIL needs it).

Include it here to build it for every device.

Link to OpenGapps issue:
https://github.com/opengapps/opengapps/issues/390

Change-Id: Iffee0aa6218dfef45f5cd728a999fa1114c0dd57
Signed-off-by: Alexander Martinz <eviscerationls@gmail.com>