### PR TITLE
cm: overlay: Enable auto-power-save modes globally

### DIFF
--- a/overlay/common/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/common/frameworks/base/core/res/res/values/config.xml
@@ -61,4 +61,13 @@
 
     <!-- Whether to persist the notification for when a usb drive device is plugged in -->
     <bool name="config_persistUsbDriveNotification">true</bool>
+
+    <!-- Set this to true to enable the platform's auto-power-save modes like doze and
+         app standby.  These are not enabled by default because they require a standard
+         cloud-to-device messaging service for apps to interact correctly with the modes
+         (such as to be able to deliver an instant message to the device even when it is
+         dozing).  This should be enabled if you have such services and expect apps to
+         correctly use them when installed on your device.  Otherwise, keep this disabled
+         so that applications can still use their own mechanisms. -->
+    <bool name="config_enableAutoPowerModes">true</bool>
 </resources>


### PR DESCRIPTION
The framework disables aggressive power-save modes when appropriate,
such as when the device lacks a significant motion detector.

Thus, instead of enabling it in each device tree,
enable it by default for all devices.

Change-Id: I1999b04876f1ddce1574c050b6bc582e9a9a96da